### PR TITLE
Add API rate limiting (per-IP + global daily cap)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-rate-limiting.md
+++ b/docs/superpowers/plans/2026-06-20-rate-limiting.md
@@ -1,0 +1,331 @@
+# API Rate Limiting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-IP throttling plus a global daily cap to restpick's Google-spending endpoints so the app can go public without bill-runaway risk.
+
+**Architecture:** A single `RateLimitFilter` (`OncePerRequestFilter`, auto-registered as a `@Component`) runs before the controllers. For the five Google-spending endpoints it consumes one token from the caller's per-IP Bucket4j bucket and one from a shared global daily bucket; if either is empty it returns `429` and the request never reaches the controller. Per-IP buckets live in a bounded Caffeine cache. Task 0 first repairs a pre-existing red test suite (okhttp/mockwebserver version conflict) so we build on green.
+
+**Tech Stack:** Java 25, Spring Boot 4.0.5 (WAR), Bucket4j `8.14.0` (`bucket4j_jdk17-core`), Caffeine `3.2.0`, JUnit 5, Spring `MockHttpServletRequest/Response`.
+
+## Global Constraints
+
+- Java version: **25** (`pom.xml` `<java.version>25</java.version>`). Build JDK: `/home/node/.local/jdk-25.0.3+9`.
+- Build/test command (env must be set every shell — state does not persist):
+  ```bash
+  cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+  ```
+- Package: `com.ztur211.restpick`.
+- Test style: plain JUnit 5 (no `@SpringBootTest`, no Spring context); instantiate the class under test directly. Match existing tests.
+- Limits (Balanced preset, per spec): per-IP **60 / minute**; global **5,000 / day**.
+- Limited paths (context-relative `getServletPath()`): `/autocomplete`, `/pick`, `/resolve-location`, `/map-image`, `/photo`.
+- `429` response: header `Retry-After: 60`, content-type `application/json`, body `{"error":"Rate limit exceeded. Please slow down."}`.
+
+---
+
+### Task 0: Repair pre-existing test suite (okhttp/mockwebserver conflict)
+
+**Why:** A clean `mvn test` currently fails with 17 `NoClassDefFound okhttp3/internal/Util` errors. `okhttp` is pinned to `5.0.0-alpha.14` (which dropped `okhttp3.internal.Util`) while `mockwebserver:4.12.0` (used by the service tests) needs it. `okhttp` is **unused in main code** (`grep` confirms), and the tests use the okhttp-4 `MockWebServer` API. Aligning okhttp to the stable `4.12.0` fixes all 17 with one version change and no test-code churn.
+
+**Files:**
+- Modify: `pom.xml` (the `okhttp` dependency version)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a green baseline (`Tests run: 35, Failures: 0, Errors: 0`).
+
+- [ ] **Step 1: Confirm the red baseline**
+
+```bash
+cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+./mvnw -B test 2>&1 | grep -E "Tests run:|NoClassDefFound" | tail -5
+```
+Expected: `Tests run: 35, Failures: 0, Errors: 17` with `NoClassDefFound okhttp3/internal/Util`.
+
+- [ ] **Step 2: Align okhttp to 4.12.0**
+
+In `pom.xml`, change the okhttp dependency version from `5.0.0-alpha.14` to `4.12.0`:
+
+```xml
+<dependency>
+    <groupId>com.squareup.okhttp3</groupId>
+    <artifactId>okhttp</artifactId>
+    <version>4.12.0</version>
+</dependency>
+```
+
+- [ ] **Step 3: Run the full suite, expect green**
+
+```bash
+cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+./mvnw -B test 2>&1 | grep -E "Tests run:|BUILD" | tail -3
+```
+Expected: `Tests run: 35, Failures: 0, Errors: 0, Skipped: 0` and `BUILD SUCCESS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pom.xml
+git commit -m "Fix test suite: align okhttp to 4.12.0 to match mockwebserver"
+```
+
+---
+
+### Task 1: RateLimitFilter (per-IP + global daily cap)
+
+**Files:**
+- Modify: `pom.xml` (add Bucket4j + Caffeine dependencies)
+- Create: `src/main/java/com/ztur211/restpick/RateLimitFilter.java`
+- Test: `src/test/java/com/ztur211/restpick/RateLimitFilterTest.java`
+
+**Interfaces:**
+- Consumes: green baseline from Task 0.
+- Produces: `RateLimitFilter` — public no-arg constructor (production, 60/min + 5000/day); package-private `RateLimitFilter(int perIpPerMinute, long globalPerDay)` for tests. Extends `OncePerRequestFilter`; overrides `doFilterInternal`.
+
+- [ ] **Step 1: Add dependencies to `pom.xml`**
+
+Add inside `<dependencies>`:
+
+```xml
+<dependency>
+    <groupId>com.bucket4j</groupId>
+    <artifactId>bucket4j_jdk17-core</artifactId>
+    <version>8.14.0</version>
+</dependency>
+<dependency>
+    <groupId>com.github.ben-manes.caffeine</groupId>
+    <artifactId>caffeine</artifactId>
+    <version>3.2.0</version>
+</dependency>
+```
+
+Verify resolution:
+```bash
+cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+./mvnw -B -q dependency:resolve 2>&1 | tail -3 && echo OK
+```
+Expected: no error, prints `OK`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/test/java/com/ztur211/restpick/RateLimitFilterTest.java`:
+
+```java
+package com.ztur211.restpick;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimitFilterTest {
+
+    // Minimal FilterChain that records how many times it was invoked.
+    static class CountingChain implements FilterChain {
+        int count = 0;
+        public void doFilter(ServletRequest req, ServletResponse res) { count++; }
+    }
+
+    private MockHttpServletRequest req(String path, String ip) {
+        MockHttpServletRequest r = new MockHttpServletRequest();
+        r.setServletPath(path);
+        r.setRemoteAddr(ip);
+        return r;
+    }
+
+    @Test
+    void perIp_blocksAfterCapacity() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(2, 1000); // 2/min per IP
+
+        for (int i = 0; i < 2; i++) {
+            CountingChain chain = new CountingChain();
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilter(req("/pick", "1.2.3.4"), res, chain);
+            assertEquals(1, chain.count, "request " + i + " should pass through");
+            assertEquals(200, res.getStatus());
+        }
+
+        CountingChain chain = new CountingChain();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "1.2.3.4"), res, chain);
+        assertEquals(0, chain.count, "3rd request must be blocked");
+        assertEquals(429, res.getStatus());
+        assertEquals("60", res.getHeader("Retry-After"));
+        assertTrue(res.getContentAsString().contains("Rate limit exceeded"));
+    }
+
+    @Test
+    void differentIps_areIndependent() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1, 1000); // 1/min per IP
+
+        MockHttpServletResponse a1 = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "10.0.0.1"), a1, new CountingChain());
+        assertEquals(200, a1.getStatus());
+
+        MockHttpServletResponse a2 = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "10.0.0.1"), a2, new CountingChain());
+        assertEquals(429, a2.getStatus(), "same IP second request blocked");
+
+        MockHttpServletResponse b1 = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "10.0.0.2"), b1, new CountingChain());
+        assertEquals(200, b1.getStatus(), "different IP unaffected");
+    }
+
+    @Test
+    void globalCap_blocksRegardlessOfIp() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1000, 3); // big per-IP, global 3/day
+
+        for (int i = 0; i < 3; i++) {
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilter(req("/photo", "172.16.0." + i), res, new CountingChain());
+            assertEquals(200, res.getStatus(), "global request " + i + " allowed");
+        }
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        filter.doFilter(req("/photo", "172.16.0.99"), res, new CountingChain());
+        assertEquals(429, res.getStatus(), "global cap exhausted");
+    }
+
+    @Test
+    void nonLimitedPath_alwaysPasses() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1, 1); // tiny limits
+
+        for (int i = 0; i < 3; i++) {
+            CountingChain chain = new CountingChain();
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilter(req("/", "9.9.9.9"), res, chain);
+            assertEquals(1, chain.count, "home page never throttled");
+            assertEquals(200, res.getStatus());
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails to compile (class missing)**
+
+```bash
+cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+./mvnw -B test -Dtest=RateLimitFilterTest 2>&1 | grep -E "ERROR|BUILD" | tail -5
+```
+Expected: compilation failure — `RateLimitFilter` symbol not found.
+
+- [ ] **Step 4: Implement `RateLimitFilter`**
+
+Create `src/main/java/com/ztur211/restpick/RateLimitFilter.java`:
+
+```java
+package com.ztur211.restpick;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * Rate-limits the Google-spending endpoints: each client IP gets a per-minute
+ * budget, and a single global bucket caps total daily calls so the Google bill
+ * stays bounded even under distributed load. Other routes pass through.
+ */
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final Set<String> LIMITED_PATHS = Set.of(
+            "/autocomplete", "/pick", "/resolve-location", "/map-image", "/photo");
+
+    private final int perIpPerMinute;
+    private final Bucket globalBucket;
+    private final Cache<String, Bucket> perIpBuckets;
+
+    /** Production limits: 60 requests/min per IP, 5,000 Google calls/day total. */
+    public RateLimitFilter() {
+        this(60, 5_000);
+    }
+
+    RateLimitFilter(int perIpPerMinute, long globalPerDay) {
+        this.perIpPerMinute = perIpPerMinute;
+        this.globalBucket = Bucket.builder()
+                .addLimit(limit -> limit.capacity(globalPerDay).refillGreedy(globalPerDay, Duration.ofDays(1)))
+                .build();
+        this.perIpBuckets = Caffeine.newBuilder()
+                .maximumSize(100_000)
+                .expireAfterAccess(Duration.ofHours(1))
+                .build();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (!LIMITED_PATHS.contains(request.getServletPath())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Bucket ipBucket = perIpBuckets.get(clientIp(request), key -> Bucket.builder()
+                .addLimit(limit -> limit.capacity(perIpPerMinute).refillGreedy(perIpPerMinute, Duration.ofMinutes(1)))
+                .build());
+
+        if (ipBucket.tryConsume(1) && globalBucket.tryConsume(1)) {
+            chain.doFilter(request, response);
+        } else {
+            response.setStatus(429);
+            response.setHeader("Retry-After", "60");
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"Rate limit exceeded. Please slow down.\"}");
+        }
+    }
+
+    /** Client IP: first hop of X-Forwarded-For when present, else the socket address. */
+    private String clientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}
+```
+
+- [ ] **Step 5: Run the rate-limit tests, expect green**
+
+```bash
+cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+./mvnw -B test -Dtest=RateLimitFilterTest 2>&1 | grep -E "Tests run:|BUILD" | tail -3
+```
+Expected: `Tests run: 4, Failures: 0, Errors: 0` and `BUILD SUCCESS`.
+
+- [ ] **Step 6: Run the FULL suite, expect all green**
+
+```bash
+cd /workspace && export JAVA_HOME=/home/node/.local/jdk-25.0.3+9 && export PATH="$JAVA_HOME/bin:$PATH"
+./mvnw -B test 2>&1 | grep -E "Tests run:|BUILD" | tail -3
+```
+Expected: `Tests run: 39, Failures: 0, Errors: 0, Skipped: 0` and `BUILD SUCCESS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pom.xml src/main/java/com/ztur211/restpick/RateLimitFilter.java src/test/java/com/ztur211/restpick/RateLimitFilterTest.java
+git commit -m "Add API rate limiting (per-IP + global daily cap)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** RateLimitFilter (§Design overview) → Task 1 Step 4. Limited endpoints (§) → `LIMITED_PATHS`. Limits (§) → no-arg constructor `(60, 5000)`. Client IP / X-Forwarded-For (§) → `clientIp()`. Memory safety / Caffeine (§) → `perIpBuckets`. Error response (§) → 429 branch. Testing (§ four cases) → four `@Test` methods. WAR context-path note (§) → `getServletPath()`. Dependencies (§) → Task 1 Step 1. ✓ All covered.
+- **Placeholder scan:** none — all code and commands are concrete.
+- **Type consistency:** `RateLimitFilter(int, long)` used identically in plan and tests; `doFilterInternal` signature matches `OncePerRequestFilter`; Bucket4j `io.github.bucket4j.Bucket` + lambda `addLimit` verified against 8.14.0. ✓
+- **Bonus repair:** Task 0 fixes the pre-existing okhttp red suite so Task 1 Step 6's "39 green" is meaningful.

--- a/docs/superpowers/specs/2026-06-20-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-06-20-rate-limiting-design.md
@@ -1,0 +1,129 @@
+# Design: API Rate Limiting for restpick
+
+- **Date:** 2026-06-20
+- **Status:** Approved (pending spec review)
+- **Component:** `com.ztur211.restpick`
+
+## Problem
+
+restpick is about to be made public. Several endpoints proxy directly to paid
+Google APIs (Places Autocomplete, Nearby Search, Geocoding, Static Maps, Place
+Photos). With no rate limiting, a single abuser or a runaway bot loop can drive
+an unbounded Google bill. We need to cap abuse before exposing a public URL.
+
+## Goals
+
+- **Per-IP fairness:** no single client can spam the paid endpoints.
+- **Global ceiling:** a hard daily cap on total Google-spending calls, so the
+  bill is bounded even under distributed load.
+- **Graceful failure:** rejected requests return `429` with a clear message;
+  the existing frontend already handles error responses on these endpoints.
+- **Minimal footprint:** one filter, two dependencies, one test file.
+
+## Non-goals (YAGNI)
+
+- Authentication / API keys / user accounts.
+- Distributed or cross-instance limiting (the app is a single Tomcat instance).
+- Per-endpoint limit tiers (see "Why one per-IP bucket" below).
+- Externalized/tunable config via `@ConfigurationProperties` (constants suffice;
+  trivial to externalize later if tuning-without-recompile is ever needed).
+
+## Design overview
+
+A single `RateLimitFilter extends OncePerRequestFilter`, auto-registered as a
+`@Component`, runs before the controllers. For requests to a Google-spending
+endpoint it consumes one token from the caller's per-IP bucket and one from a
+shared global daily bucket. If either is exhausted it short-circuits with `429`
+and the request never reaches the controller — so no Google call is made. All
+other routes (`/`, static assets, actuator health) pass through untouched.
+
+- **Token buckets:** [Bucket4j](https://bucket4j.com) (in-memory).
+- **Per-IP storage:** [Caffeine](https://github.com/ben-manes/caffeine) cache,
+  `IP -> Bucket`, with `maximumSize` + `expireAfterAccess` so idle IPs evict and
+  memory stays bounded. An unbounded `Map<IP, Bucket>` would itself be a
+  memory-exhaustion vector on a public URL; Caffeine closes that in ~3 lines.
+
+## Limited endpoints
+
+```
+/autocomplete      POST   Places Autocomplete
+/pick              POST   Nearby Search
+/resolve-location  POST   Geocoding / Place details
+/map-image         GET    Static Maps
+/photo             GET    Place Photos
+```
+
+Matched against a `Set<String>` using the **context-relative** path
+(`request.getServletPath()`, not `getRequestURI()`) — the app is packaged as a
+WAR with a `ServletInitializer`, so `getRequestURI()` would include the context
+path and break an exact match when deployed under a non-root context. The home
+page and static assets are intentionally excluded (no Google spend).
+
+## Limits (Balanced preset)
+
+| Bucket          | Scope    | Capacity / Refill        |
+|-----------------|----------|--------------------------|
+| Per-IP          | each IP  | 60 tokens, +60 / minute  |
+| Global (daily)  | all IPs  | 5,000 tokens, +5,000 / day |
+
+### Why one per-IP bucket (not per-endpoint)
+
+Frontend evidence (`src/main/resources/static/js/index.js`):
+
+- **Autocomplete is already debounced** (300 ms) and only fires at >= 3 chars
+  (`index.js:16,23`), so it cannot spam — a few calls while typing at most.
+- **A single "Pick" fires a burst of media calls** — `showResult` renders a
+  photo carousel with one `/photo` request *per photo* (up to ~10) plus one
+  `/map-image`, all at once (`index.js:291,348`).
+
+So the only real burst is a pick-with-photos (~10 calls). A single per-IP
+bucket of 60/min absorbs several such picks plus typing per minute — generous
+for a human, restrictive for a bot — without the complexity of per-endpoint
+tiers.
+
+## Client identification
+
+Bucket key = client IP, read from the first hop of `X-Forwarded-For` when
+present, falling back to `request.getRemoteAddr()`. This matters if the app is
+ever fronted by a tunnel/proxy. `X-Forwarded-For` is spoofable, so per-IP
+limiting is *fairness*, not hard security — the global daily cap is the
+backstop against spoofed/distributed abuse.
+
+## Error response
+
+On exhaustion of either bucket:
+
+- Status: `429 Too Many Requests`
+- Header: `Retry-After: 60`
+- Body: `{"error":"Rate limit exceeded. Please slow down."}` (`application/json`)
+
+Consumption order: per-IP first, then global. If per-IP succeeds but global is
+exhausted, one per-IP token is spent on a rejected request — immaterial at
+these volumes and not worth a two-phase reservation.
+
+## Dependencies (pom.xml)
+
+- Bucket4j core (JDK 17+ artifact, compatible with the project's Java 25 /
+  Spring Boot 4.0.5 baseline).
+- Caffeine.
+
+Exact coordinates/versions are pinned during implementation.
+
+## Testing
+
+One focused test class on the filter (matching the project's existing
+per-class unit-test style), with Google-calling services mocked so no real API
+calls occur:
+
+1. **Per-IP limit trips:** the 61st request from one IP within a minute → `429`.
+2. **IPs are independent:** a second IP is unaffected by the first IP's usage.
+3. **Global cap trips:** once the global daily total is reached, further
+   requests → `429` regardless of IP.
+4. **Non-limited path passes:** `/` (or a static asset) is never throttled.
+
+## Rollout notes
+
+- No schema or API contract changes; purely additive.
+- Limits are constants in the filter; adjust and rebuild to re-tune.
+- After deploy, the global cap can be observed via logs / actuator if a counter
+  is later exposed (out of scope here).

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>5.0.0-alpha.14</version>
+			<version>4.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,16 @@
 			<version>4.12.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j_jdk17-core</artifactId>
+			<version>8.14.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.2.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/com/ztur211/restpick/RateLimitFilter.java
+++ b/src/main/java/com/ztur211/restpick/RateLimitFilter.java
@@ -1,0 +1,78 @@
+package com.ztur211.restpick;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * Rate-limits the Google-spending endpoints: each client IP gets a per-minute
+ * budget, and a single global bucket caps total daily calls so the Google bill
+ * stays bounded even under distributed load. Other routes pass through.
+ */
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final Set<String> LIMITED_PATHS = Set.of(
+            "/autocomplete", "/pick", "/resolve-location", "/map-image", "/photo");
+
+    private final int perIpPerMinute;
+    private final Bucket globalBucket;
+    private final Cache<String, Bucket> perIpBuckets;
+
+    /** Production limits: 60 requests/min per IP, 5,000 Google calls/day total. */
+    public RateLimitFilter() {
+        this(60, 5_000);
+    }
+
+    RateLimitFilter(int perIpPerMinute, long globalPerDay) {
+        this.perIpPerMinute = perIpPerMinute;
+        this.globalBucket = Bucket.builder()
+                .addLimit(limit -> limit.capacity(globalPerDay).refillGreedy(globalPerDay, Duration.ofDays(1)))
+                .build();
+        this.perIpBuckets = Caffeine.newBuilder()
+                .maximumSize(100_000)
+                .expireAfterAccess(Duration.ofHours(1))
+                .build();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (!LIMITED_PATHS.contains(request.getServletPath())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Bucket ipBucket = perIpBuckets.get(clientIp(request), key -> Bucket.builder()
+                .addLimit(limit -> limit.capacity(perIpPerMinute).refillGreedy(perIpPerMinute, Duration.ofMinutes(1)))
+                .build());
+
+        if (ipBucket.tryConsume(1) && globalBucket.tryConsume(1)) {
+            chain.doFilter(request, response);
+        } else {
+            response.setStatus(429);
+            response.setHeader("Retry-After", "60");
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"Rate limit exceeded. Please slow down.\"}");
+        }
+    }
+
+    /** Client IP: first hop of X-Forwarded-For when present, else the socket address. */
+    private String clientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/test/java/com/ztur211/restpick/AutocompleteServiceTest.java
+++ b/src/test/java/com/ztur211/restpick/AutocompleteServiceTest.java
@@ -1,44 +1,37 @@
 package com.ztur211.restpick;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 class AutocompleteServiceTest {
 
-    private MockWebServer mockWebServer;
+    private static final String AUTOCOMPLETE_URL = "https://places.googleapis.com/v1/places:autocomplete";
+    private static final String PLACE_DETAILS_URL = "https://places.googleapis.com/v1/places/";
+
     private AutocompleteService autocompleteService;
+    private MockRestServiceServer mockServer;
 
     @BeforeEach
-    void setUp() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
-
-        WebClient webClient = WebClient.builder()
-                .baseUrl(mockWebServer.url("/").toString())
-                .build();
-
+    void setUp() {
         autocompleteService = new AutocompleteService();
-        ReflectionTestUtils.setField(autocompleteService, "webClient", webClient);
         ReflectionTestUtils.setField(autocompleteService, "apiKey", "test-api-key");
         ReflectionTestUtils.setField(autocompleteService, "apiLanguage", "en");
         ReflectionTestUtils.setField(autocompleteService, "apiRegion", "us");
-        ReflectionTestUtils.setField(autocompleteService, "baseUrl", mockWebServer.url("").toString().replaceAll("/$", ""));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        mockWebServer.shutdown();
+        // Bind MockRestServiceServer to the service's real RestTemplate (no production change).
+        RestTemplate restTemplate = (RestTemplate) ReflectionTestUtils.getField(autocompleteService, "restTemplate");
+        mockServer = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test
@@ -66,9 +59,9 @@ class AutocompleteServiceTest {
                         }
                     ]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(responseJson));
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
         List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("New", null, null);
 
@@ -77,26 +70,29 @@ class AutocompleteServiceTest {
         assertEquals("NY, USA", results.get(0).getSecondaryText());
         assertEquals("placeId1", results.get(0).getPlaceId());
         assertEquals("New Orleans", results.get(1).getMainText());
+        mockServer.verify();
     }
 
     @Test
     void getSuggestions_nullBody_returnsEmptyList() {
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("null"));
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
 
         List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
         assertTrue(results.isEmpty());
+        mockServer.verify();
     }
 
     @Test
     void getSuggestions_nullSuggestions_returnsEmptyList() {
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{}"));
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
         List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
         assertTrue(results.isEmpty());
+        mockServer.verify();
     }
 
     @Test
@@ -116,13 +112,14 @@ class AutocompleteServiceTest {
                         }
                     ]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(responseJson));
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
         List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
         assertEquals(1, results.size());
         assertEquals("Valid", results.get(0).getMainText());
+        mockServer.verify();
     }
 
     @Test
@@ -138,26 +135,28 @@ class AutocompleteServiceTest {
                         }
                     ]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(responseJson));
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
         List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
         assertEquals(1, results.size());
         assertEquals("", results.get(0).getMainText());
         assertEquals("", results.get(0).getSecondaryText());
+        mockServer.verify();
     }
 
     @Test
     void getSuggestions_multipleRegionCodes() {
         ReflectionTestUtils.setField(autocompleteService, "apiRegion", "us,ca,mx");
 
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{\"suggestions\":[]}"));
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"suggestions\":[]}", MediaType.APPLICATION_JSON));
 
         List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
         assertNotNull(results);
+        mockServer.verify();
     }
 
     @Test
@@ -166,35 +165,38 @@ class AutocompleteServiceTest {
                 {
                     "location": {"latitude": 40.7128, "longitude": -74.006}
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(responseJson));
+        mockServer.expect(requestTo(PLACE_DETAILS_URL + "placeId123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
         Map<String, Double> result = autocompleteService.getLocation("placeId123");
 
         assertEquals(40.7128, result.get("latitude"));
         assertEquals(-74.006, result.get("longitude"));
+        mockServer.verify();
     }
 
     @Test
     void getLocation_nullBody_throws() {
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("null"));
+        mockServer.expect(requestTo(PLACE_DETAILS_URL + "placeId123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> autocompleteService.getLocation("placeId123"));
         assertTrue(ex.getMessage().contains("Error fetching place details"));
+        mockServer.verify();
     }
 
     @Test
     void getLocation_noLocationKey_throws() {
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{}"));
+        mockServer.expect(requestTo(PLACE_DETAILS_URL + "placeId123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> autocompleteService.getLocation("placeId123"));
         assertTrue(ex.getMessage().contains("Error fetching place details"));
+        mockServer.verify();
     }
 }

--- a/src/test/java/com/ztur211/restpick/RateLimitFilterTest.java
+++ b/src/test/java/com/ztur211/restpick/RateLimitFilterTest.java
@@ -1,0 +1,92 @@
+package com.ztur211.restpick;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimitFilterTest {
+
+    // Minimal FilterChain that records how many times it was invoked.
+    static class CountingChain implements FilterChain {
+        int count = 0;
+        public void doFilter(ServletRequest req, ServletResponse res) { count++; }
+    }
+
+    private MockHttpServletRequest req(String path, String ip) {
+        MockHttpServletRequest r = new MockHttpServletRequest();
+        r.setServletPath(path);
+        r.setRemoteAddr(ip);
+        return r;
+    }
+
+    @Test
+    void perIp_blocksAfterCapacity() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(2, 1000); // 2/min per IP
+
+        for (int i = 0; i < 2; i++) {
+            CountingChain chain = new CountingChain();
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilter(req("/pick", "1.2.3.4"), res, chain);
+            assertEquals(1, chain.count, "request " + i + " should pass through");
+            assertEquals(200, res.getStatus());
+        }
+
+        CountingChain chain = new CountingChain();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "1.2.3.4"), res, chain);
+        assertEquals(0, chain.count, "3rd request must be blocked");
+        assertEquals(429, res.getStatus());
+        assertEquals("60", res.getHeader("Retry-After"));
+        assertTrue(res.getContentAsString().contains("Rate limit exceeded"));
+    }
+
+    @Test
+    void differentIps_areIndependent() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1, 1000); // 1/min per IP
+
+        MockHttpServletResponse a1 = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "10.0.0.1"), a1, new CountingChain());
+        assertEquals(200, a1.getStatus());
+
+        MockHttpServletResponse a2 = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "10.0.0.1"), a2, new CountingChain());
+        assertEquals(429, a2.getStatus(), "same IP second request blocked");
+
+        MockHttpServletResponse b1 = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "10.0.0.2"), b1, new CountingChain());
+        assertEquals(200, b1.getStatus(), "different IP unaffected");
+    }
+
+    @Test
+    void globalCap_blocksRegardlessOfIp() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1000, 3); // big per-IP, global 3/day
+
+        for (int i = 0; i < 3; i++) {
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilter(req("/photo", "172.16.0." + i), res, new CountingChain());
+            assertEquals(200, res.getStatus(), "global request " + i + " allowed");
+        }
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        filter.doFilter(req("/photo", "172.16.0.99"), res, new CountingChain());
+        assertEquals(429, res.getStatus(), "global cap exhausted");
+    }
+
+    @Test
+    void nonLimitedPath_alwaysPasses() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1, 1); // tiny limits
+
+        for (int i = 0; i < 3; i++) {
+            CountingChain chain = new CountingChain();
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilter(req("/", "9.9.9.9"), res, chain);
+            assertEquals(1, chain.count, "home page never throttled");
+            assertEquals(200, res.getStatus());
+        }
+    }
+}

--- a/src/test/java/com/ztur211/restpick/RestaurantServiceTest.java
+++ b/src/test/java/com/ztur211/restpick/RestaurantServiceTest.java
@@ -1,45 +1,34 @@
 package com.ztur211.restpick;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
-import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 class RestaurantServiceTest {
 
-    private MockWebServer mockWebServer;
+    private static final String SEARCH_URL = "https://places.googleapis.com/v1/places:searchNearby";
+    private static final String DETAILS_BASE = "https://places.googleapis.com/v1/";
+
     private RestaurantService restaurantService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockRestServiceServer mockServer;
 
     @BeforeEach
-    void setUp() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
-
-        WebClient webClient = WebClient.builder()
-                .baseUrl(mockWebServer.url("/").toString())
-                .build();
-
+    void setUp() {
         restaurantService = new RestaurantService();
-        ReflectionTestUtils.setField(restaurantService, "webClient", webClient);
         ReflectionTestUtils.setField(restaurantService, "apiKey", "test-api-key");
-        ReflectionTestUtils.setField(restaurantService, "baseUrl", mockWebServer.url("").toString().replaceAll("/$", ""));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        mockWebServer.shutdown();
+        // Bind MockRestServiceServer to the service's real RestTemplate (no production change).
+        RestTemplate restTemplate = (RestTemplate) ReflectionTestUtils.getField(restaurantService, "restTemplate");
+        mockServer = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test
@@ -54,13 +43,14 @@ class RestaurantServiceTest {
         SearchRequest request = buildSearchRequest(40.7, -74.0, 5.0);
         restaurantService.setSearchRequest(request);
 
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{\"places\":[]}"));
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"places\":[]}", MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> restaurantService.getRandomNearbyRestaurant());
         assertTrue(ex.getMessage().contains("No restaurants found"));
+        mockServer.verify();
     }
 
     @Test
@@ -71,9 +61,9 @@ class RestaurantServiceTest {
 
         String searchResponse = """
                 {"places":[{"name":"places/abc123"}]}""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(searchResponse));
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         String detailsResponse = """
                 {
@@ -86,9 +76,9 @@ class RestaurantServiceTest {
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(detailsResponse));
+        mockServer.expect(requestTo(DETAILS_BASE + "places/abc123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
 
         Restaurant result = restaurantService.getRandomNearbyRestaurant();
 
@@ -96,19 +86,21 @@ class RestaurantServiceTest {
         assertEquals("Test Restaurant", result.getDisplayName());
         assertEquals("123 Main St", result.getFormattedAddress());
         assertEquals(4.5, result.getRating());
+        mockServer.verify();
     }
 
     @Test
-    void getRandomNearbyRestaurant_defaultCuisineWhenNoneSelected() throws Exception {
+    void getRandomNearbyRestaurant_defaultCuisineWhenNoneSelected() {
         SearchRequest request = buildSearchRequest(40.7, -74.0, 5.0);
         request.setTypes(null);
         restaurantService.setSearchRequest(request);
 
         String searchResponse = """
                 {"places":[{"name":"places/abc123"}]}""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(searchResponse));
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.includedTypes[0]").value("restaurant"))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         String detailsResponse = """
                 {
@@ -119,16 +111,13 @@ class RestaurantServiceTest {
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(detailsResponse));
+        mockServer.expect(requestTo(DETAILS_BASE + "places/abc123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
 
         Restaurant result = restaurantService.getRandomNearbyRestaurant();
         assertNotNull(result);
-
-        var recordedRequest = mockWebServer.takeRequest();
-        String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"restaurant\""));
+        mockServer.verify();
     }
 
     @Test
@@ -137,9 +126,9 @@ class RestaurantServiceTest {
         request.setRating(4.0);
         restaurantService.setSearchRequest(request);
 
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{\"places\":[{\"name\":\"places/low-rated\"}]}"));
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"places\":[{\"name\":\"places/low-rated\"}]}", MediaType.APPLICATION_JSON));
 
         String detailsResponse = """
                 {
@@ -150,13 +139,14 @@ class RestaurantServiceTest {
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(detailsResponse));
+        mockServer.expect(requestTo(DETAILS_BASE + "places/low-rated"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> restaurantService.getRandomNearbyRestaurant());
         assertTrue(ex.getMessage().contains("No restaurants matched rating/price filters"));
+        mockServer.verify();
     }
 
     @Test
@@ -165,9 +155,9 @@ class RestaurantServiceTest {
         request.setPriceLevel(List.of("PRICE_LEVEL_INEXPENSIVE"));
         restaurantService.setSearchRequest(request);
 
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{\"places\":[{\"name\":\"places/expensive\"}]}"));
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"places\":[{\"name\":\"places/expensive\"}]}", MediaType.APPLICATION_JSON));
 
         String detailsResponse = """
                 {
@@ -179,13 +169,14 @@ class RestaurantServiceTest {
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(detailsResponse));
+        mockServer.expect(requestTo(DETAILS_BASE + "places/expensive"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> restaurantService.getRandomNearbyRestaurant());
         assertTrue(ex.getMessage().contains("No restaurants matched rating/price filters"));
+        mockServer.verify();
     }
 
     @Test
@@ -193,9 +184,9 @@ class RestaurantServiceTest {
         SearchRequest request = buildSearchRequest(40.7, -74.0, 5.0);
         restaurantService.setSearchRequest(request);
 
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("{\"places\":[{\"name\":\"places/with-photos\"}]}"));
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"places\":[{\"name\":\"places/with-photos\"}]}", MediaType.APPLICATION_JSON));
 
         String detailsResponse = """
                 {
@@ -206,13 +197,14 @@ class RestaurantServiceTest {
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[{"name":"places/photos/ref1"},{"name":"places/photos/ref2"}]
                 }""";
-        mockWebServer.enqueue(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody(detailsResponse));
+        mockServer.expect(requestTo(DETAILS_BASE + "places/with-photos"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
 
         Restaurant result = restaurantService.getRandomNearbyRestaurant();
         assertEquals(2, result.getPhotos().size());
         assertEquals("places/photos/ref1", result.getPhotos().get(0));
+        mockServer.verify();
     }
 
     @Test


### PR DESCRIPTION
## Why

The app is going public, and several endpoints proxy directly to **paid Google APIs** (`/autocomplete`, `/pick`, `/resolve-location`, `/map-image`, `/photo`). With no rate limiting, a single abuser or a runaway bot could drive an unbounded Google bill. This adds a guardrail before exposure.

## What

**`RateLimitFilter`** (`OncePerRequestFilter`, auto-registered) runs before the controllers on the five Google-spending endpoints; all other routes pass through untouched. When a limit is hit it returns `429 Too Many Requests` + `Retry-After` **before any Google call is made**.

- **Per-IP** bucket — 60/min (Bucket4j), stored in a bounded **Caffeine** cache with `expireAfterAccess` so the per-IP map can't grow without limit (itself a DoS vector on a public URL).
- **Global** bucket — 5,000/day, the hard ceiling on total Google spend even under distributed load.
- Client IP read from `X-Forwarded-For` (first hop) with `getRemoteAddr()` fallback, for when it runs behind a tunnel/proxy.
- Limits are constants with a package-private test constructor; no external config needed.

Design spec and implementation plan are included under `docs/superpowers/`.

## Pre-existing fixes pulled in along the way

A clean `mvn test` was already **red** before this work (17 errors), which surfaced while verifying:

1. **okhttp** was pinned to `5.0.0-alpha.14` (dropped `okhttp3.internal.Util`), breaking `MockWebServer` from `mockwebserver:4.12.0`. Aligned okhttp to the stable **4.12.0** (it's unused in main code).
2. The **17 service tests** targeted an earlier `WebClient`-based design; the services now use `RestTemplate` with hardcoded Google URLs, so the tests never matched the code. Rewrote them with Spring's **`MockRestServiceServer`** bound to the real `RestTemplate` (via reflection — **no production change**), preserving each test's intent and JSON payloads.

## Tests

Full suite now **green: 39/39** (was 18 passing / 17 erroring on a clean build).

- `RateLimitFilterTest` (new, 4): per-IP limit trips, IPs independent, global cap trips regardless of IP, non-limited paths never throttled.
- `RestpickApplicationTests` confirms the filter bean loads in the full Spring context.

> Note: building requires **JDK 25** per `pom.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)