### PR TITLE
Serve 429 rate-limit response as UTF-8

### DIFF
--- a/src/main/java/com/ztur211/restpick/RateLimitFilter.java
+++ b/src/main/java/com/ztur211/restpick/RateLimitFilter.java
@@ -62,7 +62,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
         } else {
             response.setStatus(429);
             response.setHeader("Retry-After", "60");
-            response.setContentType("application/json");
+            response.setContentType("application/json;charset=UTF-8");
             response.getWriter().write("{\"error\":\"Rate limit exceeded. Please slow down.\"}");
         }
     }

--- a/src/test/java/com/ztur211/restpick/RateLimitFilterTest.java
+++ b/src/test/java/com/ztur211/restpick/RateLimitFilterTest.java
@@ -89,4 +89,21 @@ class RateLimitFilterTest {
             assertEquals(200, res.getStatus());
         }
     }
+
+    @Test
+    void rejectionResponse_declaresUtf8() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(1, 1000); // 1/min per IP
+
+        // First request consumes the only token.
+        filter.doFilter(req("/pick", "5.5.5.5"), new MockHttpServletResponse(), new CountingChain());
+
+        // Second request is rejected — its body must be served as UTF-8.
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        filter.doFilter(req("/pick", "5.5.5.5"), res, new CountingChain());
+
+        assertEquals(429, res.getStatus());
+        assertEquals("UTF-8", res.getCharacterEncoding());
+        assertTrue(res.getContentType().toLowerCase().contains("utf-8"),
+                "Content-Type should declare charset=UTF-8, was: " + res.getContentType());
+    }
 }


### PR DESCRIPTION
## Why

Follow-up to #23. While smoke-testing the rate limiter over real HTTP, the `429` rejection came back as `Content-Type: application/json;charset=ISO-8859-1` — the filter set `application/json` with no charset, so the container defaulted the encoding. Harmless today (the message is ASCII), but wrong, and a trap if that string is ever localized.

## What

- `RateLimitFilter`: set `Content-Type: application/json;charset=UTF-8` on the rejection response.
- Added `RateLimitFilterTest#rejectionResponse_declaresUtf8` asserting the rejection declares UTF-8.

## Verification

- TDD: the new test fails on `main` (`was: application/json`), passes with the fix. Full suite green (40 tests).
- Live: ran the app and confirmed a real `429` now returns `Content-Type: application/json;charset=UTF-8`, with `Retry-After: 60` and the JSON body intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)