### PR TITLE
Cut Google API calls per Pick (~21 → 1) + lazy photos, session tokens, cache headers

### DIFF
--- a/src/main/java/com/ztur211/restpick/AutocompleteService.java
+++ b/src/main/java/com/ztur211/restpick/AutocompleteService.java
@@ -24,7 +24,7 @@ public class AutocompleteService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public List<AutocompleteSuggestion> getSuggestions(String input, Double biasLat, Double biasLng) {
+    public List<AutocompleteSuggestion> getSuggestions(String input, Double biasLat, Double biasLng, String sessionToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("X-Goog-Api-Key", apiKey);
@@ -41,7 +41,10 @@ public class AutocompleteService {
         List<String> regionCodes = Arrays.asList(apiRegion.split(","));
         payload.put("includedRegionCodes", regionCodes);
         payload.put("includeQueryPredictions", false);
-        payload.put("sessionToken", UUID.randomUUID().toString());
+        // One token across a user's autocomplete keystrokes + the resolve-location call groups
+        // them into a single (cheaper) session. Fall back to a fresh token if none is supplied.
+        payload.put("sessionToken",
+                (sessionToken != null && !sessionToken.isBlank()) ? sessionToken : UUID.randomUUID().toString());
         
         System.out.println("Input: " + input);
 
@@ -111,8 +114,12 @@ public class AutocompleteService {
             throw new RuntimeException("Error fetching autocomplete suggestions: " + e.getMessage());
         }
     }
-    public Map<String, Double> getLocation(String placeId) {
+    public Map<String, Double> getLocation(String placeId, String sessionToken) {
         String url = PLACE_DETAILS_URL + placeId;
+        // Link this Place Details call to the autocomplete session for session-based billing.
+        if (sessionToken != null && !sessionToken.isBlank()) {
+            url += "?sessionToken=" + sessionToken;
+        }
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("X-Goog-Api-Key", apiKey);

--- a/src/main/java/com/ztur211/restpick/IndexController.java
+++ b/src/main/java/com/ztur211/restpick/IndexController.java
@@ -9,6 +9,9 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.CacheControl;
+
+import java.time.Duration;
 
 import java.util.Map;
 
@@ -51,10 +54,11 @@ public class IndexController {
         
         Double biasLat = body.get("biasLatitude") != null ? ((Number) body.get("biasLatitude")).doubleValue() : null;
         Double biasLng = body.get("biasLongitude") != null ? ((Number) body.get("biasLongitude")).doubleValue() : null;
+        String sessionToken = (String) body.get("sessionToken");
 
         try {
             System.out.println("Calling autocomplete service with input: " + input);
-            return ResponseEntity.ok(autocompleteService.getSuggestions(input, biasLat, biasLng));
+            return ResponseEntity.ok(autocompleteService.getSuggestions(input, biasLat, biasLng, sessionToken));
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
@@ -86,8 +90,9 @@ public class IndexController {
         if (name == null || name.trim().isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of("error", "name is required"));
         }
+        String sessionToken = body.get("sessionToken");
         try {
-            return ResponseEntity.ok(autocompleteService.getLocation(name));
+            return ResponseEntity.ok(autocompleteService.getLocation(name, sessionToken));
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
@@ -111,6 +116,7 @@ public class IndexController {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.IMAGE_PNG);
+        headers.setCacheControl(CacheControl.maxAge(Duration.ofDays(7)).cachePublic());
 
         return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
     }
@@ -125,6 +131,7 @@ public class IndexController {
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.IMAGE_JPEG);
+            headers.setCacheControl(CacheControl.maxAge(Duration.ofDays(7)).cachePublic());
 
             return new ResponseEntity<>(bytes, headers, HttpStatus.OK);
 

--- a/src/main/java/com/ztur211/restpick/Place.java
+++ b/src/main/java/com/ztur211/restpick/Place.java
@@ -9,7 +9,7 @@ public class Place {
     private String formattedAddress;
     private String websiteUri;
     private Double rating;
-    private Integer ratingCount;
+    private Integer userRatingCount;
     private String priceLevel;
     private Location location;
     private List<Photo> photos;
@@ -49,11 +49,11 @@ public class Place {
         this.rating = rating;
     }
 
-    public Integer getRatingCount() {
-        return ratingCount;
+    public Integer getUserRatingCount() {
+        return userRatingCount;
     }
-    public void setRatingCount(Integer ratingCount) {
-        this.ratingCount = ratingCount;
+    public void setUserRatingCount(Integer userRatingCount) {
+        this.userRatingCount = userRatingCount;
     }
 
     public String getPriceLevel() {

--- a/src/main/java/com/ztur211/restpick/RestaurantService.java
+++ b/src/main/java/com/ztur211/restpick/RestaurantService.java
@@ -8,7 +8,6 @@ import org.springframework.web.client.RestTemplate;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 // Service class that contains the business logic for fetching nearby restaurants based on user criteria and picking a random one
 @Service
@@ -58,7 +57,7 @@ public class RestaurantService {
         payload.put("maxResultCount", MAX_RESULTS);
         payload.put("locationRestriction", Map.of(
             "circle", Map.of(
-                "center", Map.of("latitude", latitude, "longitude", longitude), 
+                "center", Map.of("latitude", latitude, "longitude", longitude),
                 "radius", radiusMeters
             )
         ));
@@ -68,12 +67,13 @@ public class RestaurantService {
             payload.put("openNow", true);
         }
 
-        // Headers
+        // Headers. The field mask now includes userRatingCount + photos so the single
+        // Nearby Search returns everything we filter and display on — no per-place
+        // Place Details calls needed.
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("X-Goog-Api-Key", apiKey);
-        headers.set("X-Goog-FieldMask", "places.name,places.displayName,places.formattedAddress,places.websiteUri,places.rating,places.priceLevel,places.location");
-
+        headers.set("X-Goog-FieldMask", "places.name,places.displayName,places.formattedAddress,places.websiteUri,places.rating,places.userRatingCount,places.priceLevel,places.location,places.photos");
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
 
@@ -81,80 +81,56 @@ public class RestaurantService {
         System.out.println(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(payload));
 
         try {
-            // Call Nearby Search
+            // Single Nearby Search call (1 API call) instead of 1 search + up to 20 Place Details.
             ResponseEntity<PlacesResponse> response = restTemplate.postForEntity(
-                SEARCH_URL, 
-                request, 
+                SEARCH_URL,
+                request,
                 PlacesResponse.class
             );
-            System.out.println("=== GOOGLE PLACES RAW RESPONSE ===");
-            System.out.println(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(response.getBody()));
 
             List<Place> places = response.getBody().getPlaces();
             if (places == null || places.isEmpty()) {
                 throw new RuntimeException("No restaurants found matching the criteria.");
             }
 
-             // Fetch details and filter
+            Double minRating = currentSearch.getRating();
+            List<String> allowedPrices = currentSearch.getPriceLevel();
+
             List<Restaurant> filtered = new ArrayList<>();
-            
             for (Place p : places) {
-                // Fetch full details for the selected restaurant
-                String detailsUrl = "https://places.googleapis.com/v1/" + p.getName();
-
-                HttpHeaders detailsHeaders = new HttpHeaders();
-                detailsHeaders.set("X-Goog-Api-Key", apiKey);
-                detailsHeaders.set("X-Goog-FieldMask",
-                        "displayName,formattedAddress,websiteUri,rating,userRatingCount,priceLevel,location,photos");
-
-                HttpEntity<Void> detailsRequest = new HttpEntity<>(detailsHeaders);
-
-                ResponseEntity<PlaceDetailsResponse> detailsResponse = restTemplate.exchange(
-                        detailsUrl,
-                        HttpMethod.GET,
-                        detailsRequest,
-                        PlaceDetailsResponse.class
-                );
-
-                PlaceDetailsResponse details = detailsResponse.getBody();
-                if (details == null) continue;
-
-                // Apply rating filter
-                Double minRating = currentSearch.getRating();
-                if (minRating != null &&
-                        (details.getRating() == null || details.getRating() < minRating)) {
+                // Rating filter — straight off the search result, no extra API call
+                if (minRating != null && (p.getRating() == null || p.getRating() < minRating)) {
                     continue;
                 }
 
-                // Apply price filter
-                List<String> allowedPrices = currentSearch.getPriceLevel();
+                // Price filter
                 if (allowedPrices != null && !allowedPrices.isEmpty()) {
-                    String placePrice = details.getPriceLevel();
+                    String placePrice = p.getPriceLevel();
                     if (placePrice == null || !allowedPrices.contains(placePrice)) {
                         continue;
                     }
                 }
-                
-                // Get photos
+
+                // Photo references (already present in the search response)
                 List<String> photoRefs = new ArrayList<>();
-                if (details.getPhotos() != null) {
-                    for (PlaceDetailsResponse.Photo photo : details.getPhotos()) {
+                if (p.getPhotos() != null) {
+                    for (Place.Photo photo : p.getPhotos()) {
                         if (photo.getName() != null) {
                             photoRefs.add(photo.getName());
                         }
                     }
                 }
-                // System.out.println("Photos: " + randomPlace.getPhotos());
+
                 filtered.add(new Restaurant(
                     p.getName(),
-                    details.getDisplayName().getText(),
-                    details.getFormattedAddress(),
-                    details.getWebsiteUri(),
-                    details.getRating(),
-                    details.getUserRatingCount(),
-                    details.getPriceLevel(),
-                    details.getLocation().getLatitude(),
-                    details.getLocation().getLongitude(),
+                    p.getDisplayName() != null ? p.getDisplayName().getText() : null,
+                    p.getFormattedAddress(),
+                    p.getWebsiteUri(),
+                    p.getRating(),
+                    p.getUserRatingCount(),
+                    p.getPriceLevel(),
+                    p.getLocation().getLatitude(),
+                    p.getLocation().getLongitude(),
                     currentSearch.getUserAddress(),
                     photoRefs
                 ));
@@ -163,7 +139,7 @@ public class RestaurantService {
             if (filtered.isEmpty()) {
                 throw new RuntimeException("No restaurants matched rating/price filters.");
             }
-            
+
             return filtered.get(new Random().nextInt(filtered.size()));
 
         } catch (Exception e) {

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,4 +1,5 @@
 let debounceTimer;
+let sessionToken = crypto.randomUUID(); // one Autocomplete session: the keystrokes + resolve-location share it, then it's rolled
 let selectedLocation = null; // Store the selected location for biasing autocomplete results
 
 const searchInput = document.getElementById('address-input');
@@ -17,7 +18,7 @@ searchInput.addEventListener('input', () => {
         return; // Don't fetch suggestions for very short input
     }
 
-    const requestBody = { input };
+    const requestBody = { input, sessionToken };
 
     clearTimeout(debounceTimer); // Clear the previous timer
     debounceTimer = setTimeout(async() => {
@@ -87,12 +88,13 @@ async function onSuggestionSelected(suggestion) {
         const response = await fetch('/resolve-location', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: suggestion.placeId })
+            body: JSON.stringify({ name: suggestion.placeId, sessionToken })
         });
 
         if (!response.ok) throw new Error('Failed to resolve location');
 
         selectedLocation = await response.json();
+        sessionToken = crypto.randomUUID(); // selecting a place closes the session; start a fresh one
         showActionButton();
 
     } catch (error) {
@@ -282,15 +284,17 @@ function showResult(restaurant) {
         `&origin=${encodeURIComponent(restaurant.originAddress)}` + 
         `&destination=${restaurant.latitude},${restaurant.longitude}`;
 
-    const hasPhotos = Array.isArray(restaurant.photos) && restaurant.photos.length > 0;
+    const MAX_PHOTOS = 6;
+    const photos = (restaurant.photos || []).slice(0, MAX_PHOTOS); // cap how many photos we ever fetch
+    const hasPhotos = photos.length > 0;
 
     const photoCarousel = hasPhotos
         ? `
-            <div id="photoCarousel" class="carousel slide" data-bs-ride="carousel">
+            <div id="photoCarousel" class="carousel slide">
                 <div class="carousel-inner">
-                    ${restaurant.photos.map((p, i) => `
+                    ${photos.map((p, i) => `
                         <div class="carousel-item ${i === 0 ? 'active' : ''}">
-                            <img src="/photo?photoRef=${p}" class="d-block w-100 rounded">
+                            <img ${i === 0 ? `src="/photo?photoRef=${p}"` : `data-src="/photo?photoRef=${p}"`} class="d-block w-100 rounded" alt="">
                         </div>
                     `).join('')}
                 </div>
@@ -356,4 +360,14 @@ function showResult(restaurant) {
             </div>
         </div>
     `;
+
+    // Lazy-load carousel photos: only the active slide is fetched up front; each other
+    // photo hits /photo only when the user navigates to it.
+    const carouselEl = document.getElementById('photoCarousel');
+    if (carouselEl) {
+        carouselEl.addEventListener('slide.bs.carousel', (e) => {
+            const img = e.relatedTarget.querySelector('img[data-src]');
+            if (img) { img.src = img.dataset.src; img.removeAttribute('data-src'); }
+        });
+    }
 }

--- a/src/test/java/com/ztur211/restpick/AutocompleteServiceTest.java
+++ b/src/test/java/com/ztur211/restpick/AutocompleteServiceTest.java
@@ -63,7 +63,7 @@ class AutocompleteServiceTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
-        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("New", null, null);
+        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("New", null, null, null);
 
         assertEquals(2, results.size());
         assertEquals("New York", results.get(0).getMainText());
@@ -74,12 +74,23 @@ class AutocompleteServiceTest {
     }
 
     @Test
+    void getSuggestions_usesProvidedSessionToken() {
+        mockServer.expect(requestTo(AUTOCOMPLETE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.sessionToken").value("tok-123"))
+                .andRespond(withSuccess("{\"suggestions\":[]}", MediaType.APPLICATION_JSON));
+
+        autocompleteService.getSuggestions("New York", null, null, "tok-123");
+        mockServer.verify();
+    }
+
+    @Test
     void getSuggestions_nullBody_returnsEmptyList() {
         mockServer.expect(requestTo(AUTOCOMPLETE_URL))
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
 
-        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
+        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null, null);
         assertTrue(results.isEmpty());
         mockServer.verify();
     }
@@ -90,7 +101,7 @@ class AutocompleteServiceTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
+        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null, null);
         assertTrue(results.isEmpty());
         mockServer.verify();
     }
@@ -116,7 +127,7 @@ class AutocompleteServiceTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
-        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
+        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null, null);
         assertEquals(1, results.size());
         assertEquals("Valid", results.get(0).getMainText());
         mockServer.verify();
@@ -139,7 +150,7 @@ class AutocompleteServiceTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
-        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
+        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null, null);
         assertEquals(1, results.size());
         assertEquals("", results.get(0).getMainText());
         assertEquals("", results.get(0).getSecondaryText());
@@ -154,7 +165,7 @@ class AutocompleteServiceTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess("{\"suggestions\":[]}", MediaType.APPLICATION_JSON));
 
-        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null);
+        List<AutocompleteSuggestion> results = autocompleteService.getSuggestions("test", null, null, null);
         assertNotNull(results);
         mockServer.verify();
     }
@@ -169,10 +180,21 @@ class AutocompleteServiceTest {
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
 
-        Map<String, Double> result = autocompleteService.getLocation("placeId123");
+        Map<String, Double> result = autocompleteService.getLocation("placeId123", null);
 
         assertEquals(40.7128, result.get("latitude"));
         assertEquals(-74.006, result.get("longitude"));
+        mockServer.verify();
+    }
+
+    @Test
+    void getLocation_appendsSessionTokenToUrl() {
+        mockServer.expect(requestTo(PLACE_DETAILS_URL + "placeId123?sessionToken=tok-123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"location\":{\"latitude\":1.0,\"longitude\":2.0}}", MediaType.APPLICATION_JSON));
+
+        Map<String, Double> result = autocompleteService.getLocation("placeId123", "tok-123");
+        assertEquals(1.0, result.get("latitude"));
         mockServer.verify();
     }
 
@@ -183,7 +205,7 @@ class AutocompleteServiceTest {
                 .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
-                () -> autocompleteService.getLocation("placeId123"));
+                () -> autocompleteService.getLocation("placeId123", null));
         assertTrue(ex.getMessage().contains("Error fetching place details"));
         mockServer.verify();
     }
@@ -195,7 +217,7 @@ class AutocompleteServiceTest {
                 .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
-                () -> autocompleteService.getLocation("placeId123"));
+                () -> autocompleteService.getLocation("placeId123", null));
         assertTrue(ex.getMessage().contains("Error fetching place details"));
         mockServer.verify();
     }

--- a/src/test/java/com/ztur211/restpick/IndexControllerTest.java
+++ b/src/test/java/com/ztur211/restpick/IndexControllerTest.java
@@ -52,7 +52,7 @@ class IndexControllerTest {
         List<AutocompleteSuggestion> suggestions = List.of(
                 new AutocompleteSuggestion("New York", "NY, USA", "place123")
         );
-        when(autocompleteService.getSuggestions("New York", null, null))
+        when(autocompleteService.getSuggestions("New York", null, null, null))
                 .thenReturn(suggestions);
 
         ResponseEntity<?> response = controller.autocomplete(Map.of("input", "New York"));
@@ -66,12 +66,12 @@ class IndexControllerTest {
 
     @Test
     void autocomplete_withLocationBias_passesCoordinates() {
-        when(autocompleteService.getSuggestions("pizza", 40.7, -74.0))
+        when(autocompleteService.getSuggestions("pizza", 40.7, -74.0, null))
                 .thenReturn(List.of());
 
         controller.autocomplete(Map.of("input", "pizza", "biasLatitude", 40.7, "biasLongitude", -74.0));
 
-        verify(autocompleteService).getSuggestions("pizza", 40.7, -74.0);
+        verify(autocompleteService).getSuggestions("pizza", 40.7, -74.0, null);
     }
 
     @Test
@@ -93,7 +93,7 @@ class IndexControllerTest {
 
     @Test
     void autocomplete_serviceThrows_returnsBadRequest() {
-        when(autocompleteService.getSuggestions(any(), any(), any()))
+        when(autocompleteService.getSuggestions(any(), any(), any(), any()))
                 .thenThrow(new RuntimeException("API error"));
 
         ResponseEntity<?> response = controller.autocomplete(Map.of("input", "test"));
@@ -138,7 +138,7 @@ class IndexControllerTest {
 
     @Test
     void resolveLocation_withValidName_returnsCoordinates() {
-        when(autocompleteService.getLocation("place123"))
+        when(autocompleteService.getLocation("place123", null))
                 .thenReturn(Map.of("latitude", 40.7128, "longitude", -74.0060));
 
         ResponseEntity<?> response = controller.resolveLocation(Map.of("name", "place123"));
@@ -165,7 +165,7 @@ class IndexControllerTest {
 
     @Test
     void resolveLocation_serviceThrows_returnsBadRequest() {
-        when(autocompleteService.getLocation(any()))
+        when(autocompleteService.getLocation(any(), any()))
                 .thenThrow(new RuntimeException("Place not found"));
 
         ResponseEntity<?> response = controller.resolveLocation(Map.of("name", "invalid"));

--- a/src/test/java/com/ztur211/restpick/RestaurantServiceTest.java
+++ b/src/test/java/com/ztur211/restpick/RestaurantServiceTest.java
@@ -17,7 +17,6 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 class RestaurantServiceTest {
 
     private static final String SEARCH_URL = "https://places.googleapis.com/v1/places:searchNearby";
-    private static final String DETAILS_BASE = "https://places.googleapis.com/v1/";
 
     private RestaurantService restaurantService;
     private MockRestServiceServer mockServer;
@@ -54,19 +53,15 @@ class RestaurantServiceTest {
     }
 
     @Test
-    void getRandomNearbyRestaurant_returnsRestaurant() {
+    void getRandomNearbyRestaurant_returnsRestaurant_fromSearchOnly() {
         SearchRequest request = buildSearchRequest(40.7, -74.0, 5.0);
         request.setTypes(List.of("italian_restaurant"));
         restaurantService.setSearchRequest(request);
 
+        // Everything needed comes back in the ONE search response — no Place Details call.
         String searchResponse = """
-                {"places":[{"name":"places/abc123"}]}""";
-        mockServer.expect(requestTo(SEARCH_URL))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
-
-        String detailsResponse = """
-                {
+                {"places":[{
+                    "name":"places/abc123",
                     "displayName":{"text":"Test Restaurant"},
                     "formattedAddress":"123 Main St",
                     "websiteUri":"https://test.com",
@@ -75,10 +70,10 @@ class RestaurantServiceTest {
                     "priceLevel":"PRICE_LEVEL_MODERATE",
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
-                }""";
-        mockServer.expect(requestTo(DETAILS_BASE + "places/abc123"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
+                }]}""";
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         Restaurant result = restaurantService.getRandomNearbyRestaurant();
 
@@ -86,7 +81,8 @@ class RestaurantServiceTest {
         assertEquals("Test Restaurant", result.getDisplayName());
         assertEquals("123 Main St", result.getFormattedAddress());
         assertEquals(4.5, result.getRating());
-        mockServer.verify();
+        assertEquals(100, result.getRatingCount()); // proves userRatingCount maps from the search
+        mockServer.verify(); // verifies ONLY the search was called (no details request)
     }
 
     @Test
@@ -96,24 +92,19 @@ class RestaurantServiceTest {
         restaurantService.setSearchRequest(request);
 
         String searchResponse = """
-                {"places":[{"name":"places/abc123"}]}""";
-        mockServer.expect(requestTo(SEARCH_URL))
-                .andExpect(method(HttpMethod.POST))
-                .andExpect(jsonPath("$.includedTypes[0]").value("restaurant"))
-                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
-
-        String detailsResponse = """
-                {
+                {"places":[{
+                    "name":"places/abc123",
                     "displayName":{"text":"Generic Place"},
                     "formattedAddress":"456 Elm St",
                     "rating":4.0,
                     "userRatingCount":50,
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
-                }""";
-        mockServer.expect(requestTo(DETAILS_BASE + "places/abc123"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
+                }]}""";
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.includedTypes[0]").value("restaurant"))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         Restaurant result = restaurantService.getRandomNearbyRestaurant();
         assertNotNull(result);
@@ -126,22 +117,20 @@ class RestaurantServiceTest {
         request.setRating(4.0);
         restaurantService.setSearchRequest(request);
 
-        mockServer.expect(requestTo(SEARCH_URL))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess("{\"places\":[{\"name\":\"places/low-rated\"}]}", MediaType.APPLICATION_JSON));
-
-        String detailsResponse = """
-                {
+        // rating is now in the search result, so the filter runs with no extra call
+        String searchResponse = """
+                {"places":[{
+                    "name":"places/low-rated",
                     "displayName":{"text":"Bad Place"},
                     "formattedAddress":"789 Oak St",
                     "rating":2.5,
                     "userRatingCount":10,
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
-                }""";
-        mockServer.expect(requestTo(DETAILS_BASE + "places/low-rated"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
+                }]}""";
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> restaurantService.getRandomNearbyRestaurant());
@@ -155,12 +144,9 @@ class RestaurantServiceTest {
         request.setPriceLevel(List.of("PRICE_LEVEL_INEXPENSIVE"));
         restaurantService.setSearchRequest(request);
 
-        mockServer.expect(requestTo(SEARCH_URL))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess("{\"places\":[{\"name\":\"places/expensive\"}]}", MediaType.APPLICATION_JSON));
-
-        String detailsResponse = """
-                {
+        String searchResponse = """
+                {"places":[{
+                    "name":"places/expensive",
                     "displayName":{"text":"Fancy Place"},
                     "formattedAddress":"1 Rich Ave",
                     "rating":4.8,
@@ -168,10 +154,10 @@ class RestaurantServiceTest {
                     "priceLevel":"PRICE_LEVEL_EXPENSIVE",
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[]
-                }""";
-        mockServer.expect(requestTo(DETAILS_BASE + "places/expensive"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
+                }]}""";
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> restaurantService.getRandomNearbyRestaurant());
@@ -184,22 +170,19 @@ class RestaurantServiceTest {
         SearchRequest request = buildSearchRequest(40.7, -74.0, 5.0);
         restaurantService.setSearchRequest(request);
 
-        mockServer.expect(requestTo(SEARCH_URL))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess("{\"places\":[{\"name\":\"places/with-photos\"}]}", MediaType.APPLICATION_JSON));
-
-        String detailsResponse = """
-                {
+        String searchResponse = """
+                {"places":[{
+                    "name":"places/with-photos",
                     "displayName":{"text":"Photo Place"},
                     "formattedAddress":"5 Pic Lane",
                     "rating":4.0,
                     "userRatingCount":80,
                     "location":{"latitude":40.7,"longitude":-74.0},
                     "photos":[{"name":"places/photos/ref1"},{"name":"places/photos/ref2"}]
-                }""";
-        mockServer.expect(requestTo(DETAILS_BASE + "places/with-photos"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(detailsResponse, MediaType.APPLICATION_JSON));
+                }]}""";
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(searchResponse, MediaType.APPLICATION_JSON));
 
         Restaurant result = restaurantService.getRandomNearbyRestaurant();
         assertEquals(2, result.getPhotos().size());


### PR DESCRIPTION
Reduces the number (and cost) of Google Places/Maps API calls across the app. Tests updated; **44/44 green**.

## Changes

**#1 — One Nearby Search per Pick (was ~21 calls)** — the biggest win.
`getRandomNearbyRestaurant()` used to do 1 Nearby Search + a Place Details call for **every** candidate (up to 20) just to return one restaurant. The search response already (or now does, via the field mask) carries every field we filter and display on. Added `places.userRatingCount` + `places.photos` to the field mask, filter + build straight from the search results, and **deleted the per-candidate details loop**. Renamed `Place.ratingCount` → `userRatingCount` so it maps from the search.

**#2 — Cap + lazy-load result photos.** The modal fetched a `/photo` (billed) for every photo (up to ~10) up front. Now capped to 6, and only the active carousel slide loads up front — the rest load via `data-src` on `slide.bs.carousel` (and `data-bs-ride` removed so it doesn't auto-cycle through them all).

**#3 — Autocomplete session token.** Was minting a fresh random token per keystroke (no session benefit) and sending none on resolve-location. Now one token (minted client-side) spans the keystrokes + the resolve-location Place Details call, then rolls after a selection — so Google bills them as one cheaper session.

**#4 — Cache headers.** `Cache-Control: public, max-age=7d` on `/photo` and `/map-image` so repeats aren't re-fetched from Google.

## Verifying

- `RestaurantServiceTest` now expects **only** the search call (`mockServer.verify()` fails if a details call sneaks in) — proves the call reduction. New assertion confirms `userRatingCount` maps from the search.
- New `AutocompleteServiceTest` cases prove the session token reaches the payload + the Place Details URL.
- ⚠️ Tests mock Google, so confirm on first deploy that a live Pick still shows photos + review count (Nearby Search returns those per the docs, but worth a glance). Trivial to revert.

Note: `PlaceDetailsResponse.java` is now unused (left in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)