### PR TITLE
Filter improvements: radius cap fix + stop buttons resizing

### DIFF
--- a/src/main/java/com/ztur211/restpick/RestaurantService.java
+++ b/src/main/java/com/ztur211/restpick/RestaurantService.java
@@ -43,7 +43,8 @@ public class RestaurantService {
 
         double latitude = center.getLatitude();
         double longitude = center.getLongitude();
-        double radiusMeters = circle.getRadius() * 1609.34; // Miles to meters
+        // Miles to meters, capped at Google Nearby Search's 50,000 m (50 km) maximum
+        double radiusMeters = Math.min(circle.getRadius() * 1609.34, 50000);
 
         // Use selected cuisine types or default to "restaurant" if none are selected
         List<String> cuisines = currentSearch.getTypes();

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -102,8 +102,26 @@ body {
 #cuisine-dropdown,
 #hours-dropdown,
 #radius-dropdown {
-    min-width: 110px;
+    /* Fixed, equal width so the buttons never resize as selections change. */
+    width: 150px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     text-align: left;
+}
+
+/* The label fills the middle and truncates with an ellipsis only when it's too
+   long, so the emoji and the dropdown caret stay put no matter what's selected. */
+#price-dropdown span,
+#rating-dropdown span,
+#cuisine-dropdown span,
+#hours-dropdown span,
+#radius-dropdown span {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .carousel-wrapper {

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -221,7 +221,9 @@ function clearSuggestions() {
                 radius:    'radius-dropdown'
             };
             const btn = document.getElementById(buttonMap[name]);
-            btn.querySelector('span').textContent = labelText;
+            // Keep the button compact: show just the choice (e.g. "4.0+"),
+            // not the rating stars — those stay visible in the dropdown menu.
+            btn.querySelector('span').textContent = labelText.replace(/[★☆½]/g, '').trim();
         });
     });
 });

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -226,12 +226,6 @@
                                 <label class="form-check-label w-100" for="radius-25">25 miles</label>
                             </div>
                         </li>
-                        <li>
-                            <div class="form-check py-1 ps-4">
-                                <input class="form-check-input" type="radio" name="radius" id="radius-50" value="50">
-                                <label class="form-check-label w-100" for="radius-50">50 miles</label>
-                            </div>
-                        </li>
                     </ul>
                 </div>
 

--- a/src/test/java/com/ztur211/restpick/RestaurantServiceTest.java
+++ b/src/test/java/com/ztur211/restpick/RestaurantServiceTest.java
@@ -197,6 +197,24 @@ class RestaurantServiceTest {
         assertTrue(RestaurantService.ALL_CUISINE_TYPES.contains("sushi_restaurant"));
     }
 
+    @Test
+    void getRandomNearbyRestaurant_capsRadiusAtGoogleMax() {
+        // 50 miles -> 80,467 m, which exceeds Google Nearby Search's 50,000 m cap.
+        SearchRequest request = buildSearchRequest(40.7, -74.0, 50.0);
+        restaurantService.setSearchRequest(request);
+
+        mockServer.expect(requestTo(SEARCH_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.locationRestriction.circle.radius").value(50000.0))
+                .andRespond(withSuccess(
+                        "{\"places\":[{\"name\":\"places/x\",\"displayName\":{\"text\":\"X\"}," +
+                        "\"location\":{\"latitude\":1.0,\"longitude\":2.0},\"photos\":[]}]}",
+                        MediaType.APPLICATION_JSON));
+
+        restaurantService.getRandomNearbyRestaurant();
+        mockServer.verify();
+    }
+
     private SearchRequest buildSearchRequest(double lat, double lng, double radius) {
         SearchRequest.Center center = new SearchRequest.Center();
         center.setLatitude(lat);


### PR DESCRIPTION
Two related filter fixes.

## 1. Radius error fix
Selecting **50 miles** failed with `Invalid radius. Radius must be in [0, 50000] inclusively.` — 50 mi ≈ 80,467 m, over Google Nearby Search's 50,000 m cap.

- Cap the request radius at Google's 50,000 m maximum in `RestaurantService`.
- Drop the 50-mile option from the menu (max is now 25 miles), so the UI never offers a distance the API rejects.
- Added a test asserting a 50-mile request is sent at exactly 50,000 m.

## 2. Filter buttons no longer resize
The dropdown buttons grew and shrank as selections changed — worst on **Rating**, which showed the full star string (e.g. `4.0+ ★★★★☆`).

- All five buttons now have a fixed **150px** width laid out with `inline-flex`, so they stay uniform regardless of selection. The emoji stays left, the caret stays right, and an over-long label ellipsis-truncates instead of stretching the button.
- The rating button shows just the threshold (e.g. `4.0+`); the full star scale still appears in the open menu.

## Verification
- Drove the running app in a headless browser: all five buttons measured exactly 150px and the rating button rendered `★ 4.0+` after selection; the star scale remained intact in the open menu.
- Full suite green: **45 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)